### PR TITLE
Battle event mobile

### DIFF
--- a/src/components/battles/BattleEvent.css
+++ b/src/components/battles/BattleEvent.css
@@ -38,7 +38,7 @@ h4 {
   background: white;
   display: flex;
   flex-direction: column;
-  border-radius: 5px;
+  border-radius: 10px;
   height: 100%;
   padding: 1.5em;
   width: 20%;
@@ -52,4 +52,35 @@ h4 {
 
 .event-info p {
   font-weight: 700;
+}
+
+@media only screen and (max-width: 950px) {
+  .event {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .killer-info,
+  .event-info,
+  .victim-info {
+    width: 95%;
+  }
+
+  .killer-info::before,
+  .victim-info::before {
+    font-size: 2rem;
+  }
+
+  .event-info {
+    margin: 2em auto;
+  }
+
+  p {
+    font-size: 1.5rem;
+  }
+
+  h4 {
+    font-size: 2rem;
+  }
 }

--- a/src/components/battles/BattleEvent.js
+++ b/src/components/battles/BattleEvent.js
@@ -35,6 +35,7 @@ export default function BattleEvent() {
             <h4>
               {killer} [{killData.Killer.GuildName}]
             </h4>
+            <h4>{Math.floor(killData.Killer.AverageItemPower)}</h4>
             <PlayerGear player={killData.Killer} />
           </div>
 
@@ -53,6 +54,7 @@ export default function BattleEvent() {
             <h4>
               {victim} [{killData.Victim.GuildName}]
             </h4>
+            <h4>{Math.floor(killData.Victim.AverageItemPower)}</h4>
 
             <PlayerGear player={killData.Victim} />
           </div>


### PR DESCRIPTION
Added a media query for screen sizes up to 950px in width. 
Sets flex-direction to column, increases width of content, and increases font size for better mobile viewing. 
Looks much better on most smaller screen sizes. 