### PR TITLE
Gear image layout

### DIFF
--- a/src/components/player/playerGear/PlayerGear.css
+++ b/src/components/player/playerGear/PlayerGear.css
@@ -1,4 +1,8 @@
 .player-gear {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.mount {
+  grid-column: 2/3;
 }

--- a/src/components/player/playerGear/PlayerGear.js
+++ b/src/components/player/playerGear/PlayerGear.js
@@ -15,137 +15,107 @@ export default function PlayerGear({ player }) {
     });
   }
 
-  const dummyImage = 'https://dummyimage.com/217x217/0173a0/0173a0';
-
   return (
     <div className="player-gear">
-      {' '}
-      <div className="container-1 ">
-        <div className="bag">
+      <div className="bag">
+        {gear.Bag && (
           <img
-            src={
-              gear.Bag
-                ? `${spriteBaseUrl}/${gear.Bag.Type}/?quality=${gear.Bag.Quality}`
-                : dummyImage
-            }
-            alt="Bag"
+            src={`${spriteBaseUrl}/${gear.Bag.Type}/?quality=${gear.Bag.Quality}`}
+            alt="bag"
             width={217}
             height={217}
           />
-        </div>
-
-        <div className="main-hand">
-          <img
-            src={
-              gear.MainHand
-                ? `${spriteBaseUrl}/${gear.MainHand.Type}/?quality=${gear.MainHand.Quality}`
-                : dummyImage
-            }
-            alt="Main Hand"
-            width={217}
-            height={217}
-          />
-        </div>
-        <div className="potion">
-          <img
-            src={
-              gear.Potion
-                ? `${spriteBaseUrl}/${gear.Potion.Type}/?quality=${gear.Potion.Quality}`
-                : dummyImage
-            }
-            alt="Potion"
-            width={217}
-            height={217}
-          />
-        </div>
+        )}
       </div>
-      <div className="container-2 ">
-        <div className="head">
+      <div className="head">
+        {gear.Head && (
           <img
-            src={
-              gear.Head
-                ? `${spriteBaseUrl}/${gear.Head.Type}/?quality=${gear.Head.Quality}`
-                : dummyImage
-            }
+            src={`${spriteBaseUrl}/${gear.Head.Type}/?quality=${gear.Head.Quality}`}
             alt="Head Piece"
             width={217}
             height={217}
           />
-        </div>
-        <div className="chest">
-          <img
-            src={
-              gear.Armor
-                ? `${spriteBaseUrl}/${gear.Armor.Type}/?quality=${gear.Armor.Quality}`
-                : dummyImage
-            }
-            alt="Chest Piece"
-            width={217}
-            height={217}
-          />
-        </div>
-        <div className="boots">
-          <img
-            src={
-              gear.Shoes
-                ? `${spriteBaseUrl}/${gear.Shoes.Type}/?quality=${gear.Shoes.Quality}`
-                : dummyImage
-            }
-            alt="Boots"
-            width={217}
-            height={217}
-          />
-        </div>
-        <div className="mount">
-          <img
-            src={
-              gear.Mount
-                ? `${spriteBaseUrl}/${gear.Mount.Type}/?quality=${gear.Mount.Quality}`
-                : dummyImage
-            }
-            alt="Mount"
-            width={217}
-            height={217}
-          />
-        </div>
+        )}
       </div>
-      <div className="container-3 ">
-        <div className="cape">
+      <div className="cape">
+        {gear.Cape && (
           <img
-            src={
-              gear.Cape
-                ? `${spriteBaseUrl}/${gear.Cape.Type}/?quality=${gear.Cape.Quality}`
-                : dummyImage
-            }
+            src={`${spriteBaseUrl}/${gear.Cape.Type}/?quality=${gear.Cape.Quality}`}
             alt="Cape"
             width={217}
             height={217}
           />
-        </div>
-        <div className="off-hand">
+        )}
+      </div>
+      <div className="main-hand">
+        {gear.MainHand && (
           <img
-            src={
-              gear.OffHand
-                ? `${spriteBaseUrl}/${gear.OffHand.Type}/?quality=${gear.OffHand.Quality}`
-                : dummyImage
-            }
+            src={`${spriteBaseUrl}/${gear.MainHand.Type}/?quality=${gear.MainHand.Quality}`}
+            alt="Main Hand"
+            width={217}
+            height={217}
+          />
+        )}
+      </div>
+      <div className="chest">
+        {gear.Armor && (
+          <img
+            src={`${spriteBaseUrl}/${gear.Armor.Type}/?quality=${gear.Armor.Quality}`}
+            alt="Chest Piece"
+            width={217}
+            height={217}
+          />
+        )}
+      </div>
+      <div className="off-hand">
+        {gear.OffHand && (
+          <img
+            src={`${spriteBaseUrl}/${gear.OffHand.Type}/?quality=${gear.OffHand.Quality}`}
             alt="Off Hand"
             width={217}
             height={217}
           />
-        </div>
-        <div className="food">
+        )}
+      </div>
+      <div className="potion">
+        {gear.Potion && (
           <img
-            src={
-              gear.Food
-                ? `${spriteBaseUrl}/${gear.Food.Type}/?quality=${gear.Food.Quality}`
-                : dummyImage
-            }
+            src={`${spriteBaseUrl}/${gear.Potion.Type}/?quality=${gear.Potion.Quality}`}
+            alt="Potion"
+            width={217}
+            height={217}
+          />
+        )}
+      </div>
+      <div className="boots">
+        {gear.Shoes && (
+          <img
+            src={`${spriteBaseUrl}/${gear.Shoes.Type}/?quality=${gear.Shoes.Quality}`}
+            alt="Boots"
+            width={217}
+            height={217}
+          />
+        )}
+      </div>{' '}
+      <div className="food">
+        {gear.Food && (
+          <img
+            src={`${spriteBaseUrl}/${gear.Food.Type}/?quality=${gear.Food.Quality}`}
             alt="Food"
             width={217}
             height={217}
           />
-        </div>
+        )}
+      </div>
+      <div className="mount">
+        {gear.Mount && (
+          <img
+            src={`${spriteBaseUrl}/${gear.Mount.Type}/?quality=${gear.Mount.Quality}`}
+            alt="Mount"
+            width={217}
+            height={217}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Image elements are now only generated if a piece of gear was equipped in that slot. Dummy images have been completely removed. 
Removed container divs within player-gear and implemented CSS grid to properly display the equipment in the correct order. 